### PR TITLE
Add collapsible snippet creator and expandable snippet cards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 :root {
   --background: #ffffff;
@@ -21,4 +21,8 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+.icon-hover:hover {
+  @apply bg-zinc-900 cursor-pointer border-zinc-500;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,9 @@ import {
   MoonStar,
   Share2,
   ChevronDown,
+  PlusIcon,
+  MinusIcon,
+  ShareIcon,
 } from 'lucide-react';
 import { useMutation, useQuery } from 'convex/react';
 import Link from 'next/link';
@@ -98,7 +101,8 @@ export default function Home() {
     <div className='min-h-screen flex flex-col items-center pt-24 p-4'>
       <h1 className='mb-8 text-5xl font-bold flex items-center gap-2'>
         <MoonStar className='size-14 mr-2' />
-        <span className='text-foreground/60'>ek</span>(klip)<span className='text-foreground/60'>se</span>
+        <span className='text-foreground/60'>ek</span>(klip)
+        <span className='text-foreground/60'>se</span>
       </h1>
       <div className='w-full max-w-3xl space-y-8'>
         <div className='rounded-xl border border-foreground/20 overflow-hidden'>
@@ -110,12 +114,7 @@ export default function Home() {
               <Moon className='h-5 w-5' />
               New Klip
             </span>
-            <ChevronDown
-              className={cn(
-                'h-4 w-4 transition-transform',
-                showNew && 'rotate-180'
-              )}
-            />
+            {showNew ? <MinusIcon className='size-4' /> : <PlusIcon className='size-4' />}
           </button>
           {showNew && (
             <div className='flex flex-col space-y-4 border-t border-foreground/20 p-6 bg-background'>
@@ -173,9 +172,7 @@ export default function Home() {
           {snippets.map((snip) => (
             <div
               key={snip._id}
-              onClick={() =>
-                setExpandedId(expandedId === snip._id ? null : snip._id)
-              }
+              onClick={() => setExpandedId(expandedId === snip._id ? null : snip._id)}
               className={cn(
                 'rounded-2xl border border-foreground/20 p-4 cursor-pointer hover:bg-foreground/5 transition-colors',
                 expandedId === snip._id && 'bg-foreground/10'
@@ -194,6 +191,7 @@ export default function Home() {
                     {extMap[snip.language] ?? snip.language}
                   </span>
                   <Button
+                    className='icon-hover'
                     variant='ghost'
                     size='icon'
                     onClick={(e) => {
@@ -204,6 +202,7 @@ export default function Home() {
                     <Copy className='h-4 w-4' />
                   </Button>
                   <Button
+                    className='icon-hover'
                     variant='ghost'
                     size='icon'
                     onClick={(e) => {
@@ -211,9 +210,10 @@ export default function Home() {
                       download(snip);
                     }}
                   >
-                    <Download className='h-4 w-4' />
+                    <Download className='size-4' />
                   </Button>
                   <Button
+                    className='icon-hover'
                     variant='ghost'
                     size='icon'
                     onClick={(e) => {
@@ -221,7 +221,7 @@ export default function Home() {
                       share(snip);
                     }}
                   >
-                    <Share2 className='h-4 w-4' />
+                    <ShareIcon className='size-4' />
                   </Button>
                 </div>
               </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,7 @@ import {
   ShareIcon,
 } from 'lucide-react';
 import { useMutation, useQuery } from 'convex/react';
+import { api } from '../../convex/_generated/api';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 
@@ -65,8 +66,8 @@ export default function Home() {
   const [title, setTitle] = useState('');
   const [language, setLanguage] = useState('markdown');
   const [content, setContent] = useState('');
-  const snippets = useQuery<Snippet[]>('snippets:list') || [];
-  const createSnippet = useMutation('snippets:create');
+  const snippets = useQuery(api.snippets.list) || [];
+  const createSnippet = useMutation(api.snippets.create);
   const [showNew, setShowNew] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,9 +13,17 @@ import {
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { useTheme } from 'next-themes';
-import { Copy, Download, MoonStar, Share2 } from 'lucide-react';
+import {
+  Copy,
+  Download,
+  Moon,
+  MoonStar,
+  Share2,
+  ChevronDown,
+} from 'lucide-react';
 import { useMutation, useQuery } from 'convex/react';
 import Link from 'next/link';
+import { cn } from '@/lib/utils';
 
 interface Snippet {
   _id: string;
@@ -37,6 +45,18 @@ const languages = [
   'text',
 ];
 
+const extMap: Record<string, string> = {
+  typescript: 'ts',
+  javascript: 'js',
+  python: 'py',
+  jsx: 'jsx',
+  csharp: 'cs',
+  yaml: 'yml',
+  xml: 'xml',
+  markdown: 'md',
+  text: 'txt',
+};
+
 export default function Home() {
   const { theme } = useTheme();
   const [title, setTitle] = useState('');
@@ -44,6 +64,8 @@ export default function Home() {
   const [content, setContent] = useState('');
   const snippets = useQuery<Snippet[]>('snippets:list') || [];
   const createSnippet = useMutation('snippets:create');
+  const [showNew, setShowNew] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const saveSnippet = async () => {
     if (!title.trim() || !content.trim()) return;
@@ -53,18 +75,7 @@ export default function Home() {
   };
 
   const download = (snip: Snippet) => {
-    const map: Record<string, string> = {
-      typescript: 'ts',
-      javascript: 'js',
-      python: 'py',
-      jsx: 'jsx',
-      csharp: 'cs',
-      yaml: 'yml',
-      xml: 'xml',
-      markdown: 'md',
-      text: 'txt',
-    };
-    const ext = map[snip.language] ?? 'txt';
+    const ext = extMap[snip.language] ?? 'txt';
     const blob = new Blob([snip.content], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -87,82 +98,152 @@ export default function Home() {
     <div className='min-h-screen flex flex-col items-center pt-24 p-4'>
       <h1 className='mb-8 text-5xl font-bold flex items-center gap-2'>
         <MoonStar className='size-14 mr-2' />
-        ek(klip)se
+        <span className='text-foreground/60'>ek</span>(klip)<span className='text-foreground/60'>se</span>
       </h1>
       <div className='w-full max-w-3xl space-y-8'>
-        <div className='flex flex-col space-y-4 rounded-xl border border-foreground/20 p-6 bg-background'>
-          <div className='flex flex-row gap-2'>
-            <Input
-              className='rounded-md'
-              placeholder='Snippet title'
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
+        <div className='rounded-xl border border-foreground/20 overflow-hidden'>
+          <button
+            onClick={() => setShowNew(!showNew)}
+            className='flex w-full items-center justify-between p-4'
+          >
+            <span className='flex items-center gap-2'>
+              <Moon className='h-5 w-5' />
+              New Klip
+            </span>
+            <ChevronDown
+              className={cn(
+                'h-4 w-4 transition-transform',
+                showNew && 'rotate-180'
+              )}
             />
-            <Select value={language} onValueChange={setLanguage}>
-              <SelectTrigger className='rounded-md w-1/4'>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {languages.map((lang) => (
-                  <SelectItem key={lang} value={lang}>
-                    {lang}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          {language === 'markdown' || language === 'text' ? (
-            <Textarea
-              className='h-[20vh] resize-y rounded-md'
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-            />
-          ) : (
-            <div className='h-[20vh] resize-y rounded-xl border border-foreground/20 overflow-hidden'>
-              <Editor
-                height='100%'
-                theme={theme === 'dark' ? 'vs-dark' : 'light'}
-                language={language}
-                value={content}
-                onChange={(v) => setContent(v ?? '')}
-                options={{
-                  minimap: { enabled: false },
-                  lineNumbers: 'on',
-                  automaticLayout: true,
-                }}
-              />
+          </button>
+          {showNew && (
+            <div className='flex flex-col space-y-4 border-t border-foreground/20 p-6 bg-background'>
+              <div className='flex flex-row gap-2'>
+                <Input
+                  className='h-10 rounded-md'
+                  placeholder='Snippet title'
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                />
+                <Select value={language} onValueChange={setLanguage}>
+                  <SelectTrigger className='h-10 rounded-md w-1/4'>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {languages.map((lang) => (
+                      <SelectItem key={lang} value={lang}>
+                        {lang}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {language === 'markdown' || language === 'text' ? (
+                <Textarea
+                  className='h-[20vh] resize-y rounded-md'
+                  value={content}
+                  onChange={(e) => setContent(e.target.value)}
+                />
+              ) : (
+                <div className='h-[20vh] resize-y rounded-xl border border-foreground/20 overflow-hidden'>
+                  <Editor
+                    height='100%'
+                    theme={theme === 'dark' ? 'vs-dark' : 'light'}
+                    language={language}
+                    value={content}
+                    onChange={(v) => setContent(v ?? '')}
+                    options={{
+                      minimap: { enabled: false },
+                      lineNumbers: 'on',
+                      automaticLayout: true,
+                    }}
+                  />
+                </div>
+              )}
+              <div className='flex justify-end'>
+                <Button className='rounded-md' onClick={saveSnippet}>
+                  Save Klip
+                </Button>
+              </div>
             </div>
           )}
-          <div className='flex justify-end'>
-            <Button className='rounded-md' onClick={saveSnippet}>
-              Save Klip
-            </Button>
-          </div>
         </div>
         <div className='space-y-2'>
           {snippets.map((snip) => (
-            <div key={snip._id} className='relative rounded-2xl border border-foreground/20 p-4'>
-              <div className='flex items-center justify-between pr-24'>
-                <Link href={`/${snip.slug}`} className='font-medium'>
+            <div
+              key={snip._id}
+              onClick={() =>
+                setExpandedId(expandedId === snip._id ? null : snip._id)
+              }
+              className={cn(
+                'rounded-2xl border border-foreground/20 p-4 cursor-pointer hover:bg-foreground/5 transition-colors',
+                expandedId === snip._id && 'bg-foreground/10'
+              )}
+            >
+              <div className='flex items-center justify-between'>
+                <Link
+                  href={`/${snip.slug}`}
+                  className='font-medium'
+                  onClick={(e) => e.stopPropagation()}
+                >
                   {snip.name}
                 </Link>
-                <span className='text-sm text-foreground/60'>{snip.language}</span>
+                <div className='flex items-center gap-1'>
+                  <span className='text-sm text-foreground/60 mr-2'>
+                    {extMap[snip.language] ?? snip.language}
+                  </span>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigator.clipboard.writeText(snip.content);
+                    }}
+                  >
+                    <Copy className='h-4 w-4' />
+                  </Button>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      download(snip);
+                    }}
+                  >
+                    <Download className='h-4 w-4' />
+                  </Button>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      share(snip);
+                    }}
+                  >
+                    <Share2 className='h-4 w-4' />
+                  </Button>
+                </div>
               </div>
-              <div className='absolute top-2 right-2 flex gap-1'>
-                <Button
-                  variant='ghost'
-                  size='icon'
-                  onClick={() => navigator.clipboard.writeText(snip.content)}
-                >
-                  <Copy className='h-4 w-4' />
-                </Button>
-                <Button variant='ghost' size='icon' onClick={() => download(snip)}>
-                  <Download className='h-4 w-4' />
-                </Button>
-                <Button variant='ghost' size='icon' onClick={() => share(snip)}>
-                  <Share2 className='h-4 w-4' />
-                </Button>
-              </div>
+              {expandedId === snip._id && (
+                <div className='mt-4'>
+                  {snip.language === 'markdown' || snip.language === 'text' ? (
+                    <pre className='rounded-md border border-foreground/20 p-4 whitespace-pre-wrap'>
+                      {snip.content}
+                    </pre>
+                  ) : (
+                    <div className='rounded-md border border-foreground/20 overflow-hidden'>
+                      <Editor
+                        value={snip.content}
+                        language={snip.language}
+                        theme={theme === 'dark' ? 'vs-dark' : 'light'}
+                        options={{ readOnly: true, minimap: { enabled: false } }}
+                        height='40vh'
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -99,7 +99,7 @@ export default function Home() {
 
   return (
     <div className='min-h-screen flex flex-col items-center pt-24 p-4'>
-      <h1 className='mb-8 text-5xl font-bold flex items-center gap-2'>
+      <h1 className='my-30 text-5xl font-bold flex items-center gap-2'>
         <MoonStar className='size-14 mr-2' />
         <span className='text-foreground/60'>ek</span>(klip)
         <span className='text-foreground/60'>se</span>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -12,7 +12,7 @@ export function ThemeToggle() {
       size="icon"
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
     >
-      {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      {theme === "dark" ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
     </Button>
   );
 }


### PR DESCRIPTION
## Summary
- fix theme toggle icons
- add collapsible "New Klip" accordion with uniform inputs
- show snippet file extensions and expand cards to preview content
- dim surrounding letters in header

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b374a7abc8832099dad0de7a5d3250