### PR TITLE
Close new Klip form after save and improve hover state

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,6 +76,8 @@ export default function Home() {
     await createSnippet({ name: title, language, content });
     setTitle('');
     setContent('');
+    setLanguage('markdown');
+    setShowNew(false);
   };
 
   const download = (snip: Snippet) => {
@@ -109,7 +111,7 @@ export default function Home() {
         <div className='rounded-xl border border-foreground/20 overflow-hidden'>
           <button
             onClick={() => setShowNew(!showNew)}
-            className='flex w-full items-center justify-between p-4'
+            className='flex w-full items-center justify-between p-4 cursor-pointer hover:bg-foreground/5 transition-colors'
           >
             <span className='flex items-center gap-2'>
               <Moon className='h-5 w-5' />


### PR DESCRIPTION
## Summary
- collapse the New Klip form after saving and reset fields
- add cursor-pointer hover styling to the New Klip toggle button

## Testing
- `corepack pnpm lint`
- `corepack pnpm build` *(fails: Failed to fetch Geist fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b38c63661c8320bd4d9e9babbae5e0